### PR TITLE
refactor: 認証関連の処理をAuthControllerに移動

### DIFF
--- a/src/main/java/com/example/leave_request_workflow/controller/AuthController.java
+++ b/src/main/java/com/example/leave_request_workflow/controller/AuthController.java
@@ -1,0 +1,66 @@
+package com.example.leave_request_workflow.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import com.example.leave_request_workflow.config.UserService;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import com.example.leave_request_workflow.form.UserForm;
+import org.springframework.ui.Model;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.validation.BindingResult;
+import jakarta.validation.Valid;
+
+@Controller
+public class AuthController {
+
+    private final UserService userService;
+
+    /**
+     * コンストラクタ
+     */
+    public AuthController(UserService userService) {
+        this.userService = userService;
+    }
+
+    /**
+     * ログイン画面を表示
+     */
+    @GetMapping("/login")
+    public String login() {
+        return "login";
+    }
+
+    /**
+     * ダッシュボード画面を表示
+     */
+    @GetMapping("/dashboard")
+    public String dashboard() {
+        return "dashboard";
+    }
+
+    /**
+     * 登録フォームの表示
+     */
+    @GetMapping("/register")
+    public String showRegisterForm(Model model) {
+        model.addAttribute("userForm", new UserForm());
+        return "register";
+    }
+
+    /**
+     * 登録処理
+     */
+    @PostMapping("/register")
+    public String register(@Valid @ModelAttribute("userForm") UserForm form, BindingResult br,
+            RedirectAttributes ra, Model model) {
+        // バリデーションエラーがある場合は再度入力フォームを表示
+        if (br.hasErrors()) {
+            return "register";
+        }
+        userService.register(form);
+        // 成功メッセージをリダイレクト先に一度だけ渡す
+        ra.addFlashAttribute("success", "ユーザー登録が完了しました。");
+        return "redirect:/login";
+    }
+}

--- a/src/main/java/com/example/leave_request_workflow/controller/UserController.java
+++ b/src/main/java/com/example/leave_request_workflow/controller/UserController.java
@@ -5,7 +5,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import com.example.leave_request_workflow.config.UserService;
-import com.example.leave_request_workflow.form.UserForm;
 import org.springframework.ui.Model;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.springframework.validation.BindingResult;
@@ -80,46 +79,5 @@ public class UserController {
             ra.addFlashAttribute("error", e.getMessage());
             return "redirect:/users/" + id + "/edit-roles";
         }
-    }
-
-    /**
-     * ログイン画面を表示
-     */
-    @GetMapping("/login")
-    public String login() {
-        return "login";
-    }
-
-    /**
-     * ダッシュボード画面を表示
-     */
-    @GetMapping("/dashboard")
-    public String dashboard() {
-        return "dashboard";
-    }
-
-    /**
-     * 登録フォームの表示
-     */
-    @GetMapping("/register")
-    public String showRegisterForm(Model model) {
-        model.addAttribute("userForm", new UserForm());
-        return "register";
-    }
-
-    /**
-     * 登録処理
-     */
-    @PostMapping("/register")
-    public String register(@Valid @ModelAttribute("userForm") UserForm form, BindingResult br,
-            RedirectAttributes ra, Model model) {
-        // バリデーションエラーがある場合は再度入力フォームを表示
-        if (br.hasErrors()) {
-            return "register";
-        }
-        userService.register(form);
-        // 成功メッセージをリダイレクト先に一度だけ渡す
-        ra.addFlashAttribute("success", "ユーザー登録が完了しました。");
-        return "redirect:/login";
     }
 }


### PR DESCRIPTION
### 概要

以下、認証関連の処理を`UserController`から`AuthController`に移動

* `login()`
* `dashboard()`
* `showRegisterForm()`
* `register()`

### 関連issue
#2 