### PR TITLE
fix: 管理者コメント入力フォームの必須制約を削除

### DIFF
--- a/src/main/resources/templates/admin/edit-admin-comment.html
+++ b/src/main/resources/templates/admin/edit-admin-comment.html
@@ -22,7 +22,7 @@
             <div class="mb-3">
                 <label for="adminComment" class="form-label">管理者コメント</label>
                 <textarea id="adminComment" name="adminComment" rows="4" class="form-control"
-                    th:text="${form.adminComment}" required></textarea>
+                    th:text="${form.adminComment}"></textarea>
                 <span th:if="${#fields.hasErrors('adminComment')}" th:errors="*{adminComment}"
                     class="text-danger small"></span>
             </div>


### PR DESCRIPTION
Closes: #47 